### PR TITLE
fix: storybook examples

### DIFF
--- a/stories/index.js
+++ b/stories/index.js
@@ -13,6 +13,7 @@ import { action } from "@storybook/addon-actions";
 import { withInfo } from "@storybook/addon-info";
 import GeoDistanceSliderGoogleMap from "./reactivemaps/GeoDistanceSliderGoogleMap.stories";
 import GeoDistanceDropdownGoogleMap from "./reactivemaps/GeoDistanceDropdownGoogleMap.stories";
+import GeoDistanceDropDownOpenStreetMap from "./reactivemaps/GeoDistanceDropDownOpenStreetMap.stories";
 import ReactiveGoogleMapDefault from "./reactivemaps/ReactiveGoogleMap.stories";
 import ReactiveOpenStreetMapDefault from "./reactivemaps/ReactiveOpenStreetMapDefault.stories";
 import GeoDistanceSliderOpenStreetMap from "./reactivemaps/GeoDistanceSliderOpenStreetMap.stories";
@@ -522,7 +523,7 @@ storiesOf("Map Components/GeoDistanceDropdown", module)
   .add(
     "Playground with OpenStreet map",
     () => (
-      <GeoDistanceDropdownOpenStreetMap
+      <GeoDistanceDropDownOpenStreetMap
         data={[
           { distance: 100, label: "Under 100 miles" },
           { distance: 200, label: "Under 200 miles" },
@@ -626,7 +627,7 @@ storiesOf("Map Components/ReactiveGoogleMap", module)
     "With showMapStyles",
       () => (
         <ReactiveGoogleMapDefault
-          showMapStyles={boolean("showMapStyles", false)}
+          showMapStyles={boolean("showMapStyles", true)}
         />
       )
   )
@@ -1099,7 +1100,7 @@ storiesOf("Base components/TagCloud", module)
   .add(
     "With multiSelect off and defaultValue",
     () => (
-      <TagCloudDefault defaultValue={"Auckland"} />
+      <TagCloudDefault defaultValue={["Auckland"]} />
     )
   )
   .add(
@@ -1812,7 +1813,7 @@ storiesOf("Result components/ResultCard", module)
   .add(
     "With infinite loading",
     () => (
-      <ResultCardDefault scrollOnTarget={window} pagination={false} />
+      <ResultCardDefault pagination={false} />
     )
   )
   .add(
@@ -1858,7 +1859,7 @@ storiesOf("Result components/ResultCard", module)
     "With onData",
     () => (
       <ResultCardDefault onData={action("Data Changed")} />
-  )
+  ))
   .add(
     "Playground",
     () => (
@@ -1894,7 +1895,7 @@ storiesOf("Result components/ResultCard", module)
         includeFields={array("includeFields", ["*"])}
         excludeFields={array("excludeFields", [])}
       />
-    ))
+    )
   );
 
 storiesOf("Result components/ResultList", module)

--- a/stories/reactivesearch/DatePicker.stories.js
+++ b/stories/reactivesearch/DatePicker.stories.js
@@ -60,7 +60,6 @@ export default class DatePickerDefault extends Component {
 							react={{
 								and: ["DateSensor"]
 							}}
-							{...this.props}
 						>
 							{
 								({ data }) => (

--- a/stories/reactivesearch/DateRange.stories.js
+++ b/stories/reactivesearch/DateRange.stories.js
@@ -66,7 +66,6 @@ export default class DateRangeDefault extends Component {
 							react={{
 								and: ["DateSensor"]
 							}}
-							{...this.props}
 						>
 							{
 								({ data }) => (


### PR DESCRIPTION
## What this PR does?
fixes existing storybook examples that were breaking

## Stories affected
- GeoDistance with open street map
- default:true for `withShowMapstyles` for ReactiveGoogleMap
- TagCloud "With multiSelect off and defaultValue"
- ResultCard "With infinite loading"
- ResultCard playground

## Test
https://www.loom.com/share/6618a84356c74dcd8b4af1845b71bde2