### PR TITLE
feat: examples added for distinctfield prop support

### DIFF
--- a/stories/index.js
+++ b/stories/index.js
@@ -90,6 +90,7 @@ import RangeInputRSDefault from "./reactivesearch/RangeInput.stories";
 import ReactiveComponentStory from "./reactivesearch/ReactiveComponent.stories";
 import CustomRecentIcon from './reactivesearch/CustomRecentIcon';
 import CustomPopularIcon from './reactivesearch/CustomPopularIcon';
+import ReactiveComponentWithDistinctFieldProp from './reactivesearch/ReactiveComponentWithDistinctFieldProp';
 // import ReactiveElement from "./reactivesearch/ReactiveElement";
 
 import DarkStory from "./reactivesearch/Dark.stories";
@@ -121,7 +122,13 @@ storiesOf("Base components/ReactiveComponent", module)
   .add("A custom component", () => <ReactiveComponentStory />)
   .add("with onData", () => (
     <ReactiveComponentStory onData={action("Data Changed")} />
-  ));
+  ))
+	.add(
+    "With distinctField prop",
+   () => (
+      <ReactiveComponentWithDistinctFieldProp />
+    )
+  );
 
 // Reactivemaps components
 
@@ -1611,6 +1618,26 @@ storiesOf("Search components/CategorySearch", module)
 			/>
 		)
 	)
+	.add(
+    "With distinctField prop",
+   () => (
+      <CategorySearchDefault
+				title="CategorySearch"
+				dataField={['original_title', 'original_title.search']}
+				distinctField="authors.keyword"
+				distinctFieldConfig={{
+					inner_hits: {
+						name: 'most_recent',
+						size: 5,
+						sort: [{ timestamp: 'asc' }],
+					},
+					max_concurrent_group_searches: 4,
+				}}
+				categoryField="title.keyword"
+				componentId="BookSensor"
+			/>
+    )
+  )
   .add(
     "Playground",
    () => (
@@ -1761,6 +1788,22 @@ storiesOf("Result components/ReactiveList", module)
 					)
 				}}
       />
+    )
+  )
+	.add(
+    "With distinctField prop",
+   () => (
+      <ReactiveListDefault
+				distinctField="authors.keyword"
+				distinctFieldConfig={{
+					inner_hits: {
+						name: 'most_recent',
+						size: 5,
+						sort: [{ timestamp: 'asc' }],
+					},
+					max_concurrent_group_searches: 4,
+				}}
+			/>
     )
   )
   .add(
@@ -2422,6 +2465,25 @@ storiesOf("Search components/DataSearch", module)
 			/>
 		)
 	)
+	.add(
+    "With distinctField prop",
+   () => (
+      <DataSearchRSDefault
+				title="DataSearch"
+				dataField={['original_title', 'original_title.search']}
+				distinctField="authors.keyword"
+				distinctFieldConfig={{
+					inner_hits: {
+						name: 'most_recent',
+						size: 5,
+						sort: [{ timestamp: 'asc' }],
+					},
+					max_concurrent_group_searches: 4,
+				}}
+				componentId="BookSensor"
+			/>
+    )
+  )
   .add(
     "Playground",
     () => (

--- a/stories/reactivesearch/ReactiveComponentWithDistinctFieldProp.js
+++ b/stories/reactivesearch/ReactiveComponentWithDistinctFieldProp.js
@@ -1,0 +1,102 @@
+/* eslint react/prop-types: 0 */
+import React, { Component } from 'react';
+import ReactDOM from 'react-dom';
+
+import {
+	ReactiveBase,
+	ReactiveComponent,
+	ReactiveList,
+	SelectedFilters,
+} from '@appbaseio/reactivesearch';
+
+export default class ReactiveComponentDefault extends Component {
+	renderItem(data) {
+		return (
+			<div key={data._id}>
+				<h2>{data.name}</h2>
+				<p>{data.price} - {data.rating} stars rated</p>
+			</div>
+		);
+	}
+	render() {
+		return (
+			<ReactiveBase
+				app="carstore-dataset"
+				url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+				enableAppbase
+			>
+				<div className="row">
+					<div className="col">
+						<SelectedFilters />
+						<ReactiveComponent
+							componentId="CarSensor"
+							defaultQuery={() => ({
+								aggs: {
+									'brand.keyword': {
+										terms: {
+											field: 'brand.keyword',
+											order: {
+												_count: 'desc',
+											},
+											size: 1,
+										},
+									},
+								},
+							})}
+							distinctField="brand.keyword"
+							distinctFieldConfig={{
+								inner_hits: {
+									name: 'most_recent',
+									size: 5,
+									sort: [{ timestamp: 'asc' }],
+								},
+								max_concurrent_group_searches: 4,
+							}}
+							size={10}
+							{...this.props}
+						>
+							{({ data, setQuery }) => <CustomComponent data={data} setQuery={setQuery} />}
+						</ReactiveComponent>
+					</div>
+
+					<div className="col">
+						<ReactiveList
+							componentId="SearchResult"
+							dataField="name"
+							title="ReactiveList"
+							from={0}
+							size={20}
+							renderItem={this.renderItem}
+							pagination
+							react={{
+								and: 'CarSensor',
+							}}
+						/>
+					</div>
+				</div>
+			</ReactiveBase>
+		);
+	}
+}
+
+class CustomComponent extends Component {
+	setValue(value) {
+		this.props.setQuery({
+			query: {
+				term: {
+					"brand.keyword": value,
+				},
+			},
+			value,
+		});
+	}
+
+	render() {
+		if (this.props.data) {
+			return this.props.data.map(item => (
+				<div key={item._id} onClick={() => this.setValue(item.brand)}>{item.brand}</div>
+			));
+		}
+		return null;
+	}
+}


### PR DESCRIPTION
Examples added for distinctField & distinctFieldConfig props in ReactiveSearch web components - which returns distinct results based on a specified field.

For further reference please look into this PR - https://github.com/appbaseio/reactivesearch/pull/1654