### PR TITLE
feat(react): enable-strict-selection prop usage example added

### DIFF
--- a/stories/index.js
+++ b/stories/index.js
@@ -2834,6 +2834,16 @@ storiesOf("List components/SingleList", module)
       />
     )
   )
+	.add(
+    "With enableStrictSelection",
+   () => (
+      <SingleListRSDefault
+        showSearch
+        placeholder="Search Books"
+        enableStrictSelection
+      />
+    )
+  )
   .add(
     "Playground",
    () => (
@@ -3555,6 +3565,12 @@ storiesOf("List components/SingleDataList", module)
           ))
         }
       </SingleDataListRSDefault>
+    )
+  )
+	.add(
+    "With enableStrictSelection",
+    () => (
+      <SingleDataListRSDefault enableStrictSelection />
     )
   )
   .add(


### PR DESCRIPTION
- Example added in ReactiveSearch web stories for `SingleList` and `SingleDataList` to demonstrate the usage of `enableStrictSelection` prop
- Please refer to the following PR for further reference - https://github.com/appbaseio/reactivesearch/pull/1707