### PR TITLE
Feat/support date type for range components

### DIFF
--- a/stories/index.js
+++ b/stories/index.js
@@ -1051,7 +1051,7 @@ storiesOf("Range components/DynamicRangeSlider", module)
     () => (
       <DynamicRangeSliderDefault
         dataField="timestamp"
-        title="Date Ranges"
+        title="Date Range Example with queryFormat prop"
         queryFormat={select('queryFormat', ['date','basic_date','basic_date_time', 'basic_date_time_no_millis','date_time_no_millis','basic_time','basic_time_no_millis','epoch_millis','epoch_second'],'date')}
       />
     )

--- a/stories/index.js
+++ b/stories/index.js
@@ -1030,7 +1030,7 @@ storiesOf("Range components/DynamicRangeSlider", module)
     () => (
       <DynamicRangeSliderDefault
         dataField="timestamp"
-        title="Date Ranges"
+        title="Date Range Example"
         queryFormat="date"
       />
     )

--- a/stories/index.js
+++ b/stories/index.js
@@ -1040,7 +1040,7 @@ storiesOf("Range components/DynamicRangeSlider", module)
     () => (
       <DynamicRangeSliderDefault
         dataField="timestamp"
-        title="Date Ranges"
+        title="Date Range Example with URLParams prop"
         queryFormat="date"
         URLParams={boolean("URLParams (not visible on storybook)", true)}
       />

--- a/stories/index.js
+++ b/stories/index.js
@@ -4854,7 +4854,7 @@ storiesOf("Range components/RangeSlider", module)
     () => (
       <RangeSliderRSDefault
         dataField="timestamp"
-        title="Date Ranges"
+        title="Date Range Example with showHistogram prop"
         range={{
           start: new Date('2020-05-05'),
           end: new Date('2021-05-05'),

--- a/stories/index.js
+++ b/stories/index.js
@@ -1064,7 +1064,7 @@ storiesOf("Range components/DynamicRangeSlider", module)
         title="Date Range Example with calendarInterval prop"
         showHistogram={boolean('showHistogram', true)}
         queryFormat={select('queryFormat', ['date','basic_date','basic_date_time', 'basic_date_time_no_millis','date_time_no_millis','basic_time','basic_time_no_millis','epoch_millis','epoch_second'],'date')}
-        calendarInterval={select('calendarInterval', ['year','quarter','month', 'week','day','hour','minute'],'month')}
+        calendarInterval={select('calendarInterval', ['year','quarter','month', 'week','day','hour','minute'],'quarter')}
       />
     )
   )

--- a/stories/index.js
+++ b/stories/index.js
@@ -4873,7 +4873,7 @@ storiesOf("Range components/RangeSlider", module)
     () => (
       <RangeSliderRSDefault
         dataField="timestamp"
-        title="Date Ranges"
+        title="Date Range Example with calendarInterval prop"
         range={{
           start: new Date('2020-05-05'),
           end: new Date('2021-05-05'),

--- a/stories/index.js
+++ b/stories/index.js
@@ -4658,6 +4658,100 @@ storiesOf("Range components/RangeInput", module)
         tooltipTrigger={text("tooltipTrigger", "always")}
       />
     )
+  )  
+  .add(
+    "With date support",
+    () => (
+      <RangeInputRSDefault
+        dataField="timestamp"
+        title="Date Range Example"
+        range={{
+          start: new Date('2020-05-05'),
+          end: new Date('2021-05-05'),
+        }}
+        rangeLabels={{
+          start: '2020-05-05',
+          end: '2021-05-05'
+        }}
+        queryFormat="date"
+      />
+    )
+  )
+  .add(
+    "With URLParams (date type)",
+    () => (
+      <RangeInputRSDefault
+        dataField="timestamp"
+        title="Date Range Example with URLParams support"
+        range={{
+          start: new Date('2020-05-05'),
+          end: new Date('2021-05-05'),
+        }}
+        rangeLabels={{
+          start: '2020-05-05',
+          end: '2021-05-05'
+        }}
+        queryFormat="date"
+        URLParams={boolean("URLParams (not visible on storybook)", true)}
+      />
+    )
+  )
+  .add(
+    "With queryFormat (supported for date type)",
+    () => (
+      <RangeInputRSDefault
+        dataField="timestamp"
+        title="Date Range Example with queryFormat prop"
+        range={{
+          start: new Date('2020-05-05'),
+          end: new Date('2021-05-05'),
+        }}
+        rangeLabels={{
+          start: '2020-05-05',
+          end: '2021-05-05'
+        }}
+        queryFormat={select('queryFormat', ['date','basic_date','basic_date_time', 'basic_date_time_no_millis','date_time_no_millis','basic_time','basic_time_no_millis','epoch_millis','epoch_second'],'date')}
+      />
+    )
+  )
+  .add(
+    "With Histogram (date type)",
+    () => (
+      <RangeInputRSDefault
+        dataField="timestamp"
+        title="Date Range Example with showHistogram prop"
+        range={{
+          start: new Date('2020-05-05'),
+          end: new Date('2021-05-05'),
+        }}
+        rangeLabels={{
+          start: '2020-05-05',
+          end: '2021-05-05'
+        }}
+        queryFormat={select('queryFormat', ['date','basic_date','basic_date_time', 'basic_date_time_no_millis','date_time_no_millis','basic_time','basic_time_no_millis','epoch_millis','epoch_second'],'date')}
+        showHistogram={boolean('showHistogram', true)}
+      />
+    )
+  )
+  .add(
+    "With calendarInterval (supported for date type)",
+    () => (
+      <RangeInputRSDefault
+        dataField="timestamp"
+        title="Date Range Example with calendarInterval prop"
+        range={{
+          start: new Date('2020-05-05'),
+          end: new Date('2021-05-05'),
+        }}
+        rangeLabels={{
+          start: '2020-05-05',
+          end: '2021-05-05'
+        }}
+        showHistogram={boolean('showHistogram', true)}
+        queryFormat={select('queryFormat', ['date','basic_date','basic_date_time', 'basic_date_time_no_millis','date_time_no_millis','basic_time','basic_time_no_millis','epoch_millis','epoch_second'],'date')}
+        calendarInterval={select('calendarInterval', ['year','quarter','month', 'week','day','hour','minute'],'week')}
+      />
+    )
   )
   .add(
     "Playground",
@@ -4666,7 +4760,7 @@ storiesOf("Range components/RangeInput", module)
         title={text("title", "RangeSlider: Ratings")}
         dataField={select(
           "dataField",
-          ["books_count", "original_publication_year", "ratings_count"],
+          ["books_count", "original_publication_year", "ratings_count",'timestamp'],
           "books_count"
         )}
         range={object("range", {
@@ -4687,6 +4781,8 @@ storiesOf("Range components/RangeInput", module)
         showHistogram={boolean("showHistogram", true)}
         showSlider={boolean("showSlider", true)}
         URLParams={boolean("URLParams (not visible on storybook)", false)}
+        queryFormat={select('queryFormat (use with date type)', ['date','basic_date','basic_date_time', 'basic_date_time_no_millis','date_time_no_millis','basic_time','basic_time_no_millis','epoch_millis','epoch_second'],'date')}
+        calendarInterval={select('calendarInterval (use with date type)', ['year','quarter','month', 'week','day','hour','minute'],'month')}
       />
     )
   );

--- a/stories/index.js
+++ b/stories/index.js
@@ -4647,8 +4647,8 @@ storiesOf("Range components/RangeInput", module)
   );
 
 storiesOf("Range components/RangeSlider", module)
-	.addDecorator(withKnobs)
-	.addParameters({
+  .addDecorator(withKnobs)
+  .addParameters({
     readme: {
       // Show readme at the addons panel
       sidebar: removeFirstLine(SingleListReadme, 15),
@@ -4695,7 +4695,7 @@ storiesOf("Range components/RangeSlider", module)
   )
   .add(
     "Without histogram",
-   () => (
+    () => (
       <RangeSliderRSDefault
         showHistogram={boolean("showHistogram", false)}
       />
@@ -4703,8 +4703,9 @@ storiesOf("Range components/RangeSlider", module)
   )
   .add(
     "With custom histogram interval",
-   () => (
+    () => (
       <RangeSliderRSDefault
+        showHistogram={boolean("showHistogram", true)}
         interval={number("interval", 1000)}
       />
     )
@@ -4749,13 +4750,107 @@ storiesOf("Range components/RangeSlider", module)
     )
   )
   .add(
+    "With date support",
+    () => (
+      <RangeSliderRSDefault
+        dataField="timestamp"
+        title="Date Ranges"
+        range={{
+          start: new Date('2020-05-05'),
+          end: new Date('2021-05-05'),
+        }}
+        rangeLabels={{
+          start: '2020-05-05',
+          end: '2021-05-05'
+        }}
+        queryFormat="date"
+      />
+    )
+  )
+  .add(
+    "With URLParams (date type)",
+    () => (
+      <RangeSliderRSDefault
+        dataField="timestamp"
+        title="Date Ranges"
+        range={{
+          start: new Date('2020-05-05'),
+          end: new Date('2021-05-05'),
+        }}
+        rangeLabels={{
+          start: '2020-05-05',
+          end: '2021-05-05'
+        }}
+        queryFormat="date"
+        URLParams={boolean("URLParams (not visible on storybook)", true)}
+      />
+    )
+  )
+  .add(
+    "With queryFormat (supported for date type)",
+    () => (
+      <RangeSliderRSDefault
+        dataField="timestamp"
+        title="Date Ranges"
+        range={{
+          start: new Date('2020-05-05'),
+          end: new Date('2021-05-05'),
+        }}
+        rangeLabels={{
+          start: '2020-05-05',
+          end: '2021-05-05'
+        }}
+        queryFormat={select('queryFormat', ['date','basic_date','basic_date_time', 'basic_date_time_no_millis','date_time_no_millis','basic_time','basic_time_no_millis','epoch_millis','epoch_second'],'date')}
+      />
+    )
+  )
+  .add(
+    "With Histogram (date type)",
+    () => (
+      <RangeSliderRSDefault
+        dataField="timestamp"
+        title="Date Ranges"
+        range={{
+          start: new Date('2020-05-05'),
+          end: new Date('2021-05-05'),
+        }}
+        rangeLabels={{
+          start: '2020-05-05',
+          end: '2021-05-05'
+        }}
+        queryFormat={select('queryFormat', ['date','basic_date','basic_date_time', 'basic_date_time_no_millis','date_time_no_millis','basic_time','basic_time_no_millis','epoch_millis','epoch_second'],'date')}
+        showHistogram={boolean('showHistogram', true)}
+      />
+    )
+  )
+  .add(
+    "With calendarInterval (supported for date type)",
+    () => (
+      <RangeSliderRSDefault
+        dataField="timestamp"
+        title="Date Ranges"
+        range={{
+          start: new Date('2020-05-05'),
+          end: new Date('2021-05-05'),
+        }}
+        rangeLabels={{
+          start: '2020-05-05',
+          end: '2021-05-05'
+        }}
+        showHistogram={boolean('showHistogram', true)}
+        queryFormat={select('queryFormat', ['date','basic_date','basic_date_time', 'basic_date_time_no_millis','date_time_no_millis','basic_time','basic_time_no_millis','epoch_millis','epoch_second'],'date')}
+        calendarInterval={select('calendarInterval', ['year','quarter','month', 'week','day','hour','minute'],'month')}
+      />
+    )
+  )
+  .add(
     "Playground",
     () => (
       <RangeSliderRSDefault
         title={text("title", "RangeSlider: Prices")}
         dataField={select(
           "dataField",
-          ["books_count", "original_publication_year", "ratings_count"],
+          ["books_count", "original_publication_year", "ratings_count",'timestamp'],
           "books_count"
         )}
         range={object("range", {
@@ -4775,6 +4870,8 @@ storiesOf("Range components/RangeSlider", module)
         })}
         showHistogram={boolean("showHistogram", true)}
         URLParams={boolean("URLParams (not visible on storybook)", false)}
+        queryFormat={select('queryFormat (use with date type)', ['date','basic_date','basic_date_time', 'basic_date_time_no_millis','date_time_no_millis','basic_time','basic_time_no_millis','epoch_millis','epoch_second'],'date')}
+        calendarInterval={select('calendarInterval (use with date type)', ['year','quarter','month', 'week','day','hour','minute'],'month')}
       />
     )
   );

--- a/stories/index.js
+++ b/stories/index.js
@@ -1026,6 +1026,49 @@ storiesOf("Range components/DynamicRangeSlider", module)
     )
   )
   .add(
+    "With date support",
+    () => (
+      <DynamicRangeSliderDefault
+        dataField="timestamp"
+        title="Date Ranges"
+        queryFormat="date"
+      />
+    )
+  )
+  .add(
+    "With URLParams (date type)",
+    () => (
+      <DynamicRangeSliderDefault
+        dataField="timestamp"
+        title="Date Ranges"
+        queryFormat="date"
+        URLParams={boolean("URLParams (not visible on storybook)", true)}
+      />
+    )
+  )
+  .add(
+    "With queryFormat (supported for date type)",
+    () => (
+      <DynamicRangeSliderDefault
+        dataField="timestamp"
+        title="Date Ranges"
+        queryFormat={select('queryFormat', ['date','basic_date','basic_date_time', 'basic_date_time_no_millis','date_time_no_millis','basic_time','basic_time_no_millis','epoch_millis','epoch_second'],'date')}
+      />
+    )
+  )
+  .add(
+    "With calendarInterval (supported for date type)",
+    () => (
+      <DynamicRangeSliderDefault
+        dataField="timestamp"
+        title="Date Ranges"
+        showHistogram={boolean('showHistogram', true)}
+        queryFormat={select('queryFormat', ['date','basic_date','basic_date_time', 'basic_date_time_no_millis','date_time_no_millis','basic_time','basic_time_no_millis','epoch_millis','epoch_second'],'date')}
+        calendarInterval={select('calendarInterval', ['year','quarter','month', 'week','day','hour','minute'],'month')}
+      />
+    )
+  )
+  .add(
     "Playground",
    () => (
       <DynamicRangeSliderDefault
@@ -1033,7 +1076,7 @@ storiesOf("Range components/DynamicRangeSlider", module)
         showFilter={boolean("showFilter", true)}
         dataField={select(
           "dataField",
-          ["books_count", "original_publication_year", "ratings_count"],
+          ["books_count", "original_publication_year", "ratings_count",'timestamp'],
           "books_count"
         )}
         defaultValue={(min, max) => ({
@@ -1043,6 +1086,8 @@ storiesOf("Range components/DynamicRangeSlider", module)
         stepValue={number("stepValue", 1)}
         showHistogram={boolean("showHistogram", true)}
         URLParams={boolean("URLParams (not visible on storybook)", false)}
+        queryFormat={select('queryFormat', ['date','basic_date','basic_date_time', 'basic_date_time_no_millis','date_time_no_millis','basic_time','basic_time_no_millis','epoch_millis','epoch_second'],'date')}
+        calendarInterval={select('calendarInterval', ['year','quarter','month', 'week','day','hour','minute'],'month')}
       />
     )
   );

--- a/stories/index.js
+++ b/stories/index.js
@@ -4799,7 +4799,7 @@ storiesOf("Range components/RangeSlider", module)
     () => (
       <RangeSliderRSDefault
         dataField="timestamp"
-        title="Date Ranges"
+        title="Date Range Example"
         range={{
           start: new Date('2020-05-05'),
           end: new Date('2021-05-05'),

--- a/stories/index.js
+++ b/stories/index.js
@@ -4739,10 +4739,10 @@ storiesOf("Range components/RangeSlider", module)
     )
   )
   .add(
-    "Without histogram",
+    "With histogram",
     () => (
       <RangeSliderRSDefault
-        showHistogram={boolean("showHistogram", false)}
+        showHistogram={boolean("showHistogram", true)}
       />
     )
   )
@@ -4884,7 +4884,7 @@ storiesOf("Range components/RangeSlider", module)
         }}
         showHistogram={boolean('showHistogram', true)}
         queryFormat={select('queryFormat', ['date','basic_date','basic_date_time', 'basic_date_time_no_millis','date_time_no_millis','basic_time','basic_time_no_millis','epoch_millis','epoch_second'],'date')}
-        calendarInterval={select('calendarInterval', ['year','quarter','month', 'week','day','hour','minute'],'month')}
+        calendarInterval={select('calendarInterval', ['year','quarter','month', 'week','day','hour','minute'],'week')}
       />
     )
   )

--- a/stories/index.js
+++ b/stories/index.js
@@ -1061,7 +1061,7 @@ storiesOf("Range components/DynamicRangeSlider", module)
     () => (
       <DynamicRangeSliderDefault
         dataField="timestamp"
-        title="Date Ranges"
+        title="Date Range Example with calendarInterval prop"
         showHistogram={boolean('showHistogram', true)}
         queryFormat={select('queryFormat', ['date','basic_date','basic_date_time', 'basic_date_time_no_millis','date_time_no_millis','basic_time','basic_time_no_millis','epoch_millis','epoch_second'],'date')}
         calendarInterval={select('calendarInterval', ['year','quarter','month', 'week','day','hour','minute'],'month')}

--- a/stories/index.js
+++ b/stories/index.js
@@ -4817,7 +4817,7 @@ storiesOf("Range components/RangeSlider", module)
     () => (
       <RangeSliderRSDefault
         dataField="timestamp"
-        title="Date Ranges"
+        title="Date Range Example with URLParams support"
         range={{
           start: new Date('2020-05-05'),
           end: new Date('2021-05-05'),

--- a/stories/index.js
+++ b/stories/index.js
@@ -4836,7 +4836,7 @@ storiesOf("Range components/RangeSlider", module)
     () => (
       <RangeSliderRSDefault
         dataField="timestamp"
-        title="Date Ranges"
+        title="Date Range Example with queryFormat prop"
         range={{
           start: new Date('2020-05-05'),
           end: new Date('2021-05-05'),

--- a/stories/index.js
+++ b/stories/index.js
@@ -4368,7 +4368,7 @@ storiesOf("Range components/DatePicker", module)
             "basic_time",
             "basic_time_no_millis",
             "epoch_millis",
-            "epoch_seconds"
+            "epoch_second"
           ],
           "epoch_millis"
         )}
@@ -4402,7 +4402,7 @@ storiesOf("Range components/DatePicker", module)
             "basic_time",
             "basic_time_no_millis",
             "epoch_millis",
-            "epoch_seconds"
+            "epoch_second"
           ],
           "epoch_millis"
         )}
@@ -4508,7 +4508,7 @@ storiesOf("Range components/DateRange", module)
             "basic_time",
             "basic_time_no_millis",
             "epoch_millis",
-            "epoch_seconds"
+            "epoch_second"
           ],
           "epoch_millis"
         )}
@@ -4544,7 +4544,7 @@ storiesOf("Range components/DateRange", module)
             "basic_time",
             "basic_time_no_millis",
             "epoch_millis",
-            "epoch_seconds"
+            "epoch_second"
           ],
           "epoch_millis"
         )}

--- a/stories/reactivesearch/DynamicRangeSlider.stories.js
+++ b/stories/reactivesearch/DynamicRangeSlider.stories.js
@@ -37,7 +37,6 @@ export default class DynamicRangeSliderDefault extends Component {
 							react={{
 								and: "BookSensor"
 							}}
-							{...this.props}
 						>
 							{({ data }) => (
 								<ReactiveList.ResultListWrapper>

--- a/stories/reactivesearch/RangeSlider.stories.js
+++ b/stories/reactivesearch/RangeSlider.stories.js
@@ -45,7 +45,6 @@ export default class RangeSliderDefault extends Component {
 							react={{
 								and: "BookSensor"
 							}}
-							{...this.props}
 						>
 							{({ data }) => (
 								<ReactiveList.ResultListWrapper>


### PR DESCRIPTION
**PR Type** `Feature`

**Description** Adds stories related to support of rendering of date fields (year spans or month spans) with RangeSlider and DynamicRangeSlider.

**Stories Added 👇** 
- RangeSlider
   - With date support
   - With URLParams (date type)
   - With queryFormat (supported for date type)
   - With Histogram (date type)
   - With calendarInterval (supported for date type) 
- DynamicRangeSlider
   - With date support
   - With URLParams (date type)
   - With queryFormat (supported for date type)
   - With calendarInterval (supported for date type) 

[📔  Notion](https://www.notion.so/appbase/Support-date-type-for-Range-components-76194617cb334bb89d65c57c5e825b91)

[🎥  Loom Updated 22-12-2021](https://www.loom.com/share/da29c18ec2474a9daa7a01ab15e5ca03)
[🎥  Loom Updated 20-12-2021](https://www.loom.com/share/03d2477e7c7842c2bd2d4a7c0f22b2cc)
[🎥  Loom](https://www.loom.com/share/da19f82501004502b73bcb0bb9ce3230)

**Related PR(s) 👇**   
- https://github.com/appbaseio/reactivesearch/pull/1825
- https://github.com/appbaseio/reactivecore/pull/113
--- 
> For testing locally, switch over to `feat/support-date-type-for-range-components` in all the three repos:
> `reactivesearch`, `reactivecore` & `playground`
> and run the storybook.

--- 
> TODO: awaiting backend support for testing queryformats and calendarInterval