### PR TITLE
fix(maps): storybook examples

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,3 +1,2 @@
 <link href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.4/leaflet.css" rel="stylesheet" />
-<script type="text/javascript" src="https://maps.google.com/maps/api/js?key=AIzaSyAKz3UhgSuP872fb-Aw27oPRI7M0eXkA9U&v=weekly&libraries=places"></script>
 <script defer src="https://use.fontawesome.com/releases/v5.0.2/js/all.js"></script>

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     },
     "homepage": "https://github.com/appbaseio/reactive-playground#readme",
     "dependencies": {
-        "@appbaseio/reactivemaps": "3.0.0-beta.17",
+        "@appbaseio/reactivemaps": "3.1.0-preview.3",
         "@appbaseio/reactivesearch": "3.29.1",
         "@appbaseio/docs": "appbaseio/Docs#dev",
         "moment": "^2.29.1",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     },
     "homepage": "https://github.com/appbaseio/reactive-playground#readme",
     "dependencies": {
-        "@appbaseio/reactivemaps": "3.0.0-beta.17",
-        "@appbaseio/reactivesearch": "3.29.1",
+        "@appbaseio/reactivemaps": "3.0.0",
+        "@appbaseio/reactivesearch": "3.30.3",
         "@appbaseio/docs": "appbaseio/Docs#dev",
         "moment": "^2.29.1",
         "react": "^16.8.6",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     },
     "homepage": "https://github.com/appbaseio/reactive-playground#readme",
     "dependencies": {
-        "@appbaseio/reactivemaps": "3.1.0-preview.3",
+        "@appbaseio/reactivemaps": "3.0.0-beta.17",
         "@appbaseio/reactivesearch": "3.29.1",
         "@appbaseio/docs": "appbaseio/Docs#dev",
         "moment": "^2.29.1",

--- a/stories/index.js
+++ b/stories/index.js
@@ -412,7 +412,6 @@ storiesOf("Map Components/GeoDistanceDropdown", module)
           { distance: 1000, label: "Under 1000 miles" }
         ]}
         placeholder={text("placeholder", "Search Location")}
-        placeholderDropdown={text("placeholderDropdown", "Select radius")}
       />
     )
   )

--- a/stories/index.js
+++ b/stories/index.js
@@ -598,7 +598,7 @@ storiesOf("Map Components/ReactiveGoogleMap", module)
   })
   .add(
     "Basic",
-      () => <ReactiveGoogleMapDefault />
+      () => <ReactiveGoogleMapDefault showMarkerClusters={false} />
   )
   .add(
     "With showMarkerClusters",

--- a/stories/reactivemaps/GeoDistanceDropdownGoogleMap.stories.js
+++ b/stories/reactivemaps/GeoDistanceDropdownGoogleMap.stories.js
@@ -43,8 +43,7 @@ export default class GeoDistanceDropdownDefault extends Component {
 				app="meetup_dataset"
 				url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
 				enableAppbase
-				type="meetupdata1"
-				mapKey="AIzaSyAKz3UhgSuP872fb-Aw27oPRI7M0eXkA9U"
+				mapKey="AIzaSyA9JzjtHeXg_C_hh_GdTBdLxREWdj3nsOU"
 			>
 				<div className="row">
 					<div className="col">

--- a/stories/reactivemaps/GeoDistanceDropdownGoogleMap.stories.js
+++ b/stories/reactivemaps/GeoDistanceDropdownGoogleMap.stories.js
@@ -44,6 +44,7 @@ export default class GeoDistanceDropdownDefault extends Component {
 				url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
 				enableAppbase
 				mapKey="AIzaSyA9JzjtHeXg_C_hh_GdTBdLxREWdj3nsOU"
+				mapLibraries={['places']}
 			>
 				<div className="row">
 					<div className="col">

--- a/stories/reactivemaps/GeoDistanceSliderGoogleMap.stories.js
+++ b/stories/reactivemaps/GeoDistanceSliderGoogleMap.stories.js
@@ -44,6 +44,7 @@ export default class GeoDistanceSliderDefault extends Component {
 				url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
 				enableAppbase
 				mapKey="AIzaSyA9JzjtHeXg_C_hh_GdTBdLxREWdj3nsOU"
+				mapLibraries={['places']}
 			>
 				<div className="row">
 					<div className="col">

--- a/stories/reactivemaps/GeoDistanceSliderGoogleMap.stories.js
+++ b/stories/reactivemaps/GeoDistanceSliderGoogleMap.stories.js
@@ -43,8 +43,7 @@ export default class GeoDistanceSliderDefault extends Component {
 				app="meetup_dataset"
 				url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
 				enableAppbase
-				type="meetupdata1"
-				mapKey="AIzaSyAKz3UhgSuP872fb-Aw27oPRI7M0eXkA9U"
+				mapKey="AIzaSyA9JzjtHeXg_C_hh_GdTBdLxREWdj3nsOU"
 			>
 				<div className="row">
 					<div className="col">

--- a/stories/reactivemaps/ReactiveGoogleMap.stories.js
+++ b/stories/reactivemaps/ReactiveGoogleMap.stories.js
@@ -6,7 +6,6 @@ import {
 
 import { ReactiveGoogleMap } from '@appbaseio/reactivemaps';
 
-import { Img } from "./Img.js";
 import historyPin from "./placeholder.png";
 
 export default class ReactiveGoogleMapDefault extends Component {

--- a/stories/reactivemaps/ReactiveGoogleMap.stories.js
+++ b/stories/reactivemaps/ReactiveGoogleMap.stories.js
@@ -30,7 +30,7 @@ export default class ReactiveGoogleMapDefault extends Component {
 				app="earthquakes"
 				url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
 				enableAppbase
-				mapKey="AIzaSyAKz3UhgSuP872fb-Aw27oPRI7M0eXkA9U"
+				mapKey="AIzaSyA9JzjtHeXg_C_hh_GdTBdLxREWdj3nsOU"
 			>
 				<div className="row reverse-labels">
 					<div className="col">


### PR DESCRIPTION
**PR Type** `Fix` 🐞 

**Description** The PR fixes the storybook examples for Maps library components, post-upgrade to `@react-google-maps/api ` and `render` api changes.

[📔 Notion](https://www.notion.so/appbase/Maps-leftovers-from-a7188caa32f54601adf0b04dde02e6cd)

https://www.loom.com/share/792a6e26ace8490fb199ed1dc68a463d

> Note: Please merge https://github.com/appbaseio/reactivesearch/pull/1924 and https://github.com/appbaseio/reactivesearch/pull/1925 first and make a release, post that update this PR with latest version(s). The PR is heavily dependent upon the changes from `@appbaseio/reactivesearch`.
