### PR TITLE
feat: support for tag mode in DataSearch, SearchBox

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "homepage": "https://github.com/appbaseio/reactive-playground#readme",
     "dependencies": {
         "@appbaseio/reactivemaps": "3.0.0",
-        "@appbaseio/reactivesearch": "3.38.2",
+        "@appbaseio/reactivesearch": "3.38.3",
         "@appbaseio/docs": "appbaseio/Docs#dev",
         "moment": "^2.29.1",
         "react": "^16.8.6",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "homepage": "https://github.com/appbaseio/reactive-playground#readme",
     "dependencies": {
         "@appbaseio/reactivemaps": "3.0.0",
-        "@appbaseio/reactivesearch": "3.38.3",
+        "@appbaseio/reactivesearch": "3.39.1",
         "@appbaseio/docs": "appbaseio/Docs#dev",
         "moment": "^2.29.1",
         "react": "^16.8.6",

--- a/stories/index.js
+++ b/stories/index.js
@@ -2266,6 +2266,15 @@ storiesOf("Search components/DataSearch", module)
     )
   )
   .add(
+    "With mode prop",
+    () => (
+      <DataSearchRSDefault
+        mode={select("iconPosition", ["tag", "select"], "tag")}
+        placeholder="Search Books..."
+      />
+    )
+  )    
+  .add(
     "With title",
     () => (
       <DataSearchRSDefault
@@ -2756,6 +2765,15 @@ storiesOf("Search components/SearchBox", module)
     )
   )
   .add(
+    "With mode prop",
+    () => (
+      <SearchBoxRSDefault
+        mode={select("iconPosition", ["tag", "select"], "tag")}
+        placeholder="Search Books..."
+      />
+    )
+  )  
+  .add(
     "With title",
     () => (
       <SearchBoxRSDefault
@@ -3176,7 +3194,7 @@ storiesOf("Search components/SearchBox", module)
   .add(
     "Playground",
     () => (
-      <DataSearchRSDefault
+      <SearchBoxRSDefault
         title={text("title", "DataSearch: Books...")}
         dataField={array("dataField", [{field:"original_title", weight:3}, {field:"original_title.search", weight:1}])}
         placeholder={text("placeholder", "Search Books...")}

--- a/stories/index.js
+++ b/stories/index.js
@@ -2269,11 +2269,11 @@ storiesOf("Search components/DataSearch", module)
     "With mode prop",
     () => (
       <DataSearchRSDefault
-        mode={select("iconPosition", ["tag", "select"], "tag")}
+        mode={select("mode", ["tag", "select"], "tag")}
         placeholder="Search Books..."
       />
     )
-  )    
+  )
   .add(
     "With title",
     () => (
@@ -2768,11 +2768,11 @@ storiesOf("Search components/SearchBox", module)
     "With mode prop",
     () => (
       <SearchBoxRSDefault
-        mode={select("iconPosition", ["tag", "select"], "tag")}
+        mode={select("mode", ["tag", "select"], "tag")}
         placeholder="Search Books..."
       />
     )
-  )  
+  )
   .add(
     "With title",
     () => (


### PR DESCRIPTION
**PR Type** `Feature` ⭐ 

**Description** The PR adds stories demonstrating tag(multi-select) mode in search types of components(DataSearch and SearchBox).

[📔  Notion](https://www.notion.so/appbase/DataSearch-Searchbox-Add-multi-value-search-for-React-36dadfc713e94d92a8e6a99798dd1c9c#8ef69af5b4624fd4a8dc0960eea88f02)
https://www.loom.com/share/b0b77d0c88a84e44a3b7c57d432c0522
**Related PR(s)**
- https://github.com/appbaseio/reactivesearch/pull/2051